### PR TITLE
Fix URIs handling problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,12 @@
 .kotlin
 .gradle
 **/build/
+**/schemas/
 xcuserdata
 !src/**/build/
 local.properties
 .idea
+.vscode
 .DS_Store
 captures
 .externalNativeBuild

--- a/composeApp/src/commonMain/kotlin/model/news/newsViewScreen/NewsViewContent.kt
+++ b/composeApp/src/commonMain/kotlin/model/news/newsViewScreen/NewsViewContent.kt
@@ -16,9 +16,10 @@ data class NewsViewContent(
 ) {
     @Composable
     fun getContentWithAnnotatedStrings(): List<AnnotatedString> = content.map { text ->
+        val allowedURISchemesRegexStr = "https?://|ftp://|mailto:"
         val urlRegex = Regex(
             "(\\S+?\\${SPLITTER_SUFFIX})?" +
-                "(https?://(www\\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}" +
+                "((?:$allowedURISchemesRegexStr)(www\\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}" +
                 "\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)\\b([^\\s)\\]}.,:>?;'\"]*))"
         )
         val fontSize = MaterialTheme.typography.bodyLarge.fontSize

--- a/composeApp/src/commonMain/kotlin/utils/OrioksHtmlParser.kt
+++ b/composeApp/src/commonMain/kotlin/utils/OrioksHtmlParser.kt
@@ -151,12 +151,14 @@ class OrioksHtmlParser {
             element.select("a").forEach { link ->
                 val linkText = link.text()
                 val linkHref = link.attr("href")
-                if (linkText.isNotBlank() && linkHref.isNotBlank() &&
-                    (linkText.lowercase().trim(' ', '\n', '\t', '/') != linkHref.lowercase().trim(' ', '\n', '\t', '/'))
-                ) {
-                    paragraphText = paragraphText.replace(linkText, "$linkText$SPLITTER_SUFFIX$linkHref")
-                } else if (linkHref.isNotBlank()) {
-                    paragraphText = paragraphText.replace(linkText, linkHref)
+                if (linkText.isNotBlank() && linkHref.isNotBlank()) {
+                    if (linkText.lowercase().trim(' ', '\n', '\t', '/') !=
+                                    linkHref.lowercase().trim(' ', '\n', '\t', '/')
+                    ) {
+                        paragraphText = paragraphText.replace(linkText, "$linkText$SPLITTER_SUFFIX$linkHref")
+                    } else {
+                        paragraphText = paragraphText.replace(linkText, linkHref)
+                    }
                 }
             }
             paragraphText


### PR DESCRIPTION
Fixes #26: вынес общий код в отдельную функцию для удобства, вынес проверку `linkText.isNotBlank() && linkHref.isNotBlank()` повыше. `diff` для наглядности: https://github.com/Psychosoc1al/BetterOrioksMultiplatform/compare/main...a54e0e4a44ceb360c8444946c8355e2b2a97953c.

Fixes #27: добавил схемы `mailto` (у меня действительно открывает почтовый клиент при клике) и `ftp`, последнюю чисто по приколу)0) Помешать-то он не помешает, а так вдруг кто такую ссыль кинет) 
`diff` для наглядности: https://github.com/Psychosoc1al/BetterOrioksMultiplatform/compare/a54e0e4a44ceb360c8444946c8355e2b2a97953c...9459eee1dae3c41ffaca6e49e8fe504204d7bca3.
Всякие разные URI-схемы для референса: https://en.wikipedia.org/wiki/List_of_URI_schemes.

Детали, собственно, описаны в упомянутых `issue`.

ЗЫ: да, ещё `.gitignore` подновил слегка — то, что мешалось